### PR TITLE
- Remove deprecated rules.

### DIFF
--- a/swiftlint_pem.yml
+++ b/swiftlint_pem.yml
@@ -8,7 +8,6 @@ analyzer_rules:
 opt_in_rules:
  - accessibility_label_for_image
  - accessibility_trait_for_button
- - anyobject_protocol
  - array_init
  - balanced_xctest_lifecycle
  - closure_end_indentation
@@ -36,7 +35,6 @@ opt_in_rules:
  - joined_default_parameter
  - ibinspectable_in_extension
  - identical_operands
- - inert_defer
  - last_where
  - legacy_multiple
  - let_var_whitespace
@@ -82,7 +80,6 @@ opt_in_rules:
  - unneeded_parentheses_in_closure_argument
  - unowned_variable_capture
  - untyped_error_in_catch
- - unused_capture_list
  - vertical_whitespace_between_cases
  - vertical_whitespace_closing_braces
  - weak_delegate


### PR DESCRIPTION
Попытка убрать 3 warnings:

<img width="328" alt="Screenshot 2023-09-07 at 16 50 16" src="https://github.com/readdle/RD2SwiftLintConfig/assets/63001559/a462a384-b869-4bd7-b567-6134684acf66">

> 0.51.0
Deprecate the unused_capture_list rule in favor of the Swift compiler
warning. At the same time, make it an opt-in rule.
> Deprecate the inert_defer rule in favor of the Swift compiler warning.
At the same time, make it an opt-in rule.

Proof: https://github.com/realm/SwiftLint/releases/tag/0.51.0

> 0.50.0
The anyobject_protocol rule is now deprecated and will be completely removed in a future release because it is now handled by the Swift compiler.