### PR TITLE
- Task PEM-6528: add "qa" to exceptions as it breaks rule of min 3 letters identifier name.

### DIFF
--- a/swiftlint_pem.yml
+++ b/swiftlint_pem.yml
@@ -129,6 +129,7 @@ identifier_name:
     - ok
     - cc
     - x
+    - qa
     - "y"
     - "no"
     - "_[a-zA-Z0-9]+"


### PR DESCRIPTION
Task: https://readdle-j.atlassian.net/browse/PEM-6528

Related PR: https://github.com/readdle/pdfexpert-mac/pull/2274