### PR TITLE
raise the allowed nesting level for types to 3 levels (from the defau…

### DIFF
--- a/swiftlint_base.yml
+++ b/swiftlint_base.yml
@@ -1,5 +1,6 @@
 analyzer_rules:
 - explicit_self
+
 disabled_rules:
 - trailing_whitespace
 - todo
@@ -7,12 +8,15 @@ disabled_rules:
 - type_body_length
 - file_length
 - no_fallthrough_only
+- for_where
+
 identifier_name:
   excluded:
   - id
   - "_[a-zA-Z0-9]+"
   min_length: 3
   max_length: 75
+
 opt_in_rules:
 - empty_collection_literal
 - empty_count
@@ -24,8 +28,13 @@ opt_in_rules:
 - file_types_order
 - modifier_order
 - weak_delegate
+
+nesting:
+  type_level: 3
+
 statement_position:
   statement_mode: uncuddled_else
+
 custom_rules:
   string_interpolation_in_localized_string:
     name: "String Interpolation in Localized String"


### PR DESCRIPTION
…lt 2). Disable the default for_where – we don't use it.

Обговорювали на retro (чи де там?). Короче:
- for_where https://realm.github.io/SwiftLint/for_where.html. Він увімкнений з коробки. Вимкнули. Бо нєхєр.
- в нас було прийняте обмеження на максимум 2 рівні вкладеності типів. Ми іноді юзаємо Swift namespace (той що enum). В такому випадку 2 рівні замало, бо один рівень іде тільки на namespace. Підняли до трьох.